### PR TITLE
✨ Unify horizontal and vertical ticks

### DIFF
--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -505,21 +505,19 @@ export default function Chart() {
     <div className="grid h-full grid-cols-[auto_1fr] grid-rows-[auto_1fr]">
       <div />
       <div className="flex flex-col">
-        <div className="flex flex-row gap-3">
-          <div className="min-w-3 lg:min-w-5"></div>
-          <div className="leading-none">Weeks →</div>
-        </div>
-        <div className="mb-1 flex flex-row gap-2">
-          <div className="min-w-3 lg:min-w-5"></div>
-          <div className="grid flex-grow grid-cols-52">
-            {Array.from({ length: 52 }).map((_, index) => (
-              <Tick key={index} t={index + 1} />
-            ))}
+        <div className="grid w-full grid-cols-[repeat(53,_minmax(0,_1fr))]">
+          <div className="col-span-full col-start-2">
+            <div className="ml-1 leading-none">Weeks →</div>
           </div>
+        </div>
+        <div className="flex flex-grow flex-row contain-inline-size">
+          {Array.from({ length: 53 }).map((_, index) => (
+            <Tick key={index} t={index} minIndex={1} />
+          ))}
         </div>
       </div>
       <div className="flex flex-row">
-        <div className="leading-none [writing-mode:vertical-lr]">Age →</div>
+        <div className="mt-1 leading-none [writing-mode:vertical-lr]">Age →</div>
       </div>
       <div className="flex flex-col">
         {Array.from({ length: Math.max(79, age + 20) }).map((_, index) => (

--- a/src/components/tick.tsx
+++ b/src/components/tick.tsx
@@ -1,19 +1,25 @@
-export default function Tick({ t, vertical }: { t: number; vertical?: boolean }) {
+export default function Tick({ t, vertical, minIndex }: { t: number; vertical?: boolean; minIndex?: number }) {
   const emphasize = t % 5 == 0
   return (
-    <svg viewBox="0 0 100 100" className="h-full w-full">
-      <text
-        style={{
-          fontSize: emphasize ? 60 : 50,
-          textAnchor: vertical ? "end" : "middle",
-          dominantBaseline: vertical ? "middle" : "text-after-edge",
-          fill: emphasize ? "hsl(var(--foreground))" : "hsl(var(--muted-foreground))",
-        }}
-        x={vertical ? "100%" : "50%"}
-        y={vertical ? "50%" : "100%"}
-      >
-        {t}
-      </text>
-    </svg>
+    <div className="relative aspect-square w-16 min-w-[2px] sm:m-[1px]">
+      <div className="absolute h-full w-full">
+        {t >= (minIndex || 0) && (
+          <svg viewBox="0 0 100 100" className="h-full w-full">
+            <text
+              style={{
+                fontSize: emphasize ? 60 : 50,
+                textAnchor: vertical ? "end" : "middle",
+                dominantBaseline: vertical ? "middle" : "no-change",
+                fill: emphasize ? "hsl(var(--foreground))" : "hsl(var(--muted-foreground))",
+              }}
+              x={vertical ? "85%" : "50%"}
+              y={vertical ? "50%" : "85%"}
+            >
+              {t}
+            </text>
+          </svg>
+        )}
+      </div>
+    </div>
   )
 }

--- a/src/components/year.tsx
+++ b/src/components/year.tsx
@@ -9,26 +9,11 @@ interface Props {
 
 export default function Year({ year, data }: Props) {
   return (
-    <div className="flex flex-row gap-1 sm:gap-2">
-      <div className="relative flex min-w-3 flex-grow-0 lg:min-w-5">
-        {/* <div
-          className={`absolute h-full w-full items-end text-[.8cqmax] leading-none sm:text-[.9cqmax] md:text-[1cqmax] xl:text-sm ${(year + 1) % 5 == 0 ? "font-bold" : "text-muted-foreground"}`}
-        >
-          {year}
-        </div> */}
-        <div className="absolute h-full w-full">
-          <Tick key={year} t={year} vertical />
-        </div>
-        {/* <Tick key={year} t={year} vertical /> */}
-      </div>
-      {/* <div className="flex aspect-square w-6 min-w-[2px] flex-grow-0">
-        <Tick key={year} t={year} vertical />
-      </div> */}
-      <div className="flex flex-grow flex-row contain-inline-size">
-        {Array.from({ length: 52 }).map((_, index) => (
-          <Week key={index} year={year} week={index + 1} data={data} />
-        ))}
-      </div>
+    <div className="flex flex-grow flex-row contain-inline-size">
+      <Tick key={year} t={year} vertical />
+      {Array.from({ length: 52 }).map((_, index) => (
+        <Week key={index} year={year} week={index + 1} data={data} />
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
The way I did it before, the horizontal and vertical ticks had different cells and thus weren't equal in size. This fixes that by making everything one large grid of squares. The reason I'm not using an actual css grid is because the spaces between cells have a rounding error when you use a lot of cells. Example: https://play.tailwindcss.com/xHAKyDzMfJ