### PR TITLE
💗 Keep supabase project alive

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,12 @@
+# a cron job that runs every 24 hours to keep the workflow alive
+name: Keep Supabase Project Alive
+
+on:
+  schedule:
+    - cron: "* * * * *"
+
+jobs:
+  keep-alive:
+    runs-on: ubuntu-22.04
+    steps:
+      - run: curl https://life-in-weeks-xi.vercel.app/keep-alive

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,9 +1,0 @@
-import H1 from "@/components/ui/h1"
-
-export default function Dashboard() {
-  return (
-    <>
-      <H1>Account</H1>
-    </>
-  )
-}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,9 +1,0 @@
-import H1 from "@/components/ui/h1"
-
-export default function Dashboard() {
-  return (
-    <>
-      <H1>Dashboard</H1>
-    </>
-  )
-}

--- a/src/app/keep-alive/route.ts
+++ b/src/app/keep-alive/route.ts
@@ -1,0 +1,10 @@
+import { createClient } from "@/utils/supabase/server"
+
+export async function GET(_: Request) {
+  const supabase = createClient()
+  const { data, error } = await supabase.rpc("keep_alive")
+  if (error) {
+    return new Response(error.message, { status: 500 })
+  }
+  return new Response(JSON.stringify(data), { status: 200 })
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,9 +1,0 @@
-import H1 from "@/components/ui/h1"
-
-export default function Projects() {
-  return (
-    <>
-      <H1>Projects</H1>
-    </>
-  )
-}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,9 +1,0 @@
-import H1 from "@/components/ui/h1"
-
-export default function Settings() {
-  return (
-    <>
-      <H1>Settings</H1>
-    </>
-  )
-}

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,0 +1,23 @@
+import { createServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
+
+export function createClient() {
+  const cookieStore = cookies()
+
+  return createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll()
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options))
+        } catch {
+          // The `setAll` method was called from a Server Component.
+          // This can be ignored if you have middleware refreshing
+          // user sessions.
+        }
+      },
+    },
+  })
+}

--- a/supabase/migrations/20240801211922_keep-alive.sql
+++ b/supabase/migrations/20240801211922_keep-alive.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION keep_alive()
+RETURNS float AS $$
+BEGIN
+    RETURN random();
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
This change adds a `/keep-alive` endpoint that will respond with a random number from supabase. This is to keep the free supabase project alive.